### PR TITLE
ISSUE-22527 최종 정리

### DIFF
--- a/2023/ISSUE-22527/ISSUE-22527.md
+++ b/2023/ISSUE-22527/ISSUE-22527.md
@@ -1,0 +1,294 @@
+# [ISSUE-22527](https://github.com/cilium/cilium/issues/22527) - bpf_lxc's CT programs are missing drop notifications
+
+## 연관 이슈/PR
+* [ISSUE-22529](https://github.com/cilium/cilium/issues/22529)
+* [ISSUE-22528](https://github.com/cilium/cilium/issues/22528)
+----
+
+## 이슈 내용
+`bpf_lxc.c`에 구현된 `Connection Tracking`인 CT 프로그램들이 error code를 바로 반환해서 drop된 packet을 추적하지 못하는 문제 발생.\
+`bpf_lxc.c`에 구현된 CT 프로그램 중 error code를 바로 반환 하는 부분을 `send_drop_notify` 함수로 변경하고 `bpf_lxc` 내부의 다른 CT 프로그램도 변경.
+
+## PR 제출 여부
+해당 이슈를 분석하던 중 다른 컨트리뷰터의 [PR 제출](https://github.com/cilium/cilium/pull/25426)
+
+### example
+https://github.com/cilium/cilium/blob/8f4c7e10e026ebba05d8d2fb9910b8e5c75ed5b5/bpf/bpf_lxc.c#L92
+
+---
+## [학습 내용 링크](learning.md)
+---
+## code analyze
+
+### [bpf/bpf_lxc.c](https://github.com/cilium/cilium/blob/master/bpf/bpf_lxc.c)
+```c
+#define TAIL_CT_LOOKUP4(ID, NAME, DIR, CONDITION, TARGET_ID, TARGET_NAME)	\
+declare_tailcall_if(CONDITION, ID)						\
+int NAME(struct __ctx_buff *ctx)						\
+{										\
+	struct ct_buffer4 ct_buffer = {};					\
+	int l4_off, ret = CTX_ACT_OK;						\
+	struct ipv4_ct_tuple *tuple;						\
+	struct ct_state *ct_state;						\
+	void *data, *data_end;							\
+	struct iphdr *ip4;							\
+	__u32 zero = 0;								\
+										\
+	ct_state = (struct ct_state *)&ct_buffer.ct_state;			\
+	tuple = (struct ipv4_ct_tuple *)&ct_buffer.tuple;			\
+										\
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))			\
+		return DROP_INVALID;						\
+										\
+	tuple->nexthdr = ip4->protocol;						\
+	tuple->daddr = ip4->daddr;						\
+	tuple->saddr = ip4->saddr;						\
+										\
+	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);					\
+										\
+	ct_buffer.ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, l4_off,	\
+				   DIR, ct_state, &ct_buffer.monitor);		\
+	if (ct_buffer.ret < 0)							\
+		return ct_buffer.ret;						\
+										\
+	if (map_update_elem(&CT_TAIL_CALL_BUFFER4, &zero, &ct_buffer, 0) < 0)	\
+		return DROP_INVALID_TC_BUFFER;					\
+										\
+	invoke_tailcall_if(CONDITION, TARGET_ID, TARGET_NAME);			\
+	return ret;								\
+}
+```
+### 문제가 발생한 코드 부분
+```c
+if(!revalidate_data(ctx, &data, &data_end, &ip4))
+	return DROP_INVALID;
+```
+return문의 `DROP_INVALID`를 `send_drop_notify`로 변경해야함.
+
+
+### [bpf/lib/drop.h](https://github.com/cilium/cilium/blob/master/bpf/lib/drop.h)
+* **send_drop_notify**
+`send_drop_notify`가 어떻게 정의되어있는지 확인해야 함.
+	```c	
+	#define send_drop_notify(ctx, src, dst, dst_id, reason, exitcode, direction) \
+		_send_drop_notify(__MAGIC_FILE__, __LINE__, ctx, src, dst, dst_id, \
+				  __DROP_REASON(reason), exitcode, direction)
+	```	
+`send_drop_notfiy` macro의 경우 내부적으로 `_send_drop_notify` macro를 다시 호출하는것을 확인.\
+`_send_drop_notify`가 어떻게 동작하는지 확인이 필요함.\
+`bpf/lib/drop.h`의 경우 컴파일 시점에 `DROP_NOTIFY`의 정의 유무에 따라 동작이 달라짐.
+
+#### ON
+* **struct drop_notify**
+	```c
+	struct drop_notify {
+		NOTIFY_CAPTURE_HDR
+		__u32		src_label;
+		__u32		dst_label;
+		__u32		dst_id; /* 0 for egress */
+		__u16		line;
+		__u8		file;
+		__s8		ext_error;
+		__u32		ifindex;
+	};
+	```
+* **_send_drop_notify**
+	```c
+	static __always_inline int
+	_send_drop_notify(__u8 file, __u16 line, struct __ctx_buff *ctx,
+			__u32 src, __u32 dst, __u32 dst_id,
+			__u32 reason, __u32 exitcode, enum metric_dir direction)
+	{
+		/* These fields should be constants and fit (together) in 32 bits */
+		if (!__builtin_constant_p(exitcode) || exitcode > 0xff ||
+			!__builtin_constant_p(file) || file > 0xff ||
+			!__builtin_constant_p(line) || line > 0xffff)
+			__throw_build_bug();
+
+	/* Clang 14 or higher fails for constant check, so skip it right now.
+	* Enable again once we have more understanding why.
+	*/
+	#if __clang_major__ < 14
+		if (!__builtin_constant_p(dst_id))
+			__throw_build_bug();
+	#endif
+
+		/* Non-zero 'dst_id' is only to be used for ingress. */
+		if (dst_id != 0 && (!__builtin_constant_p(direction) || direction != METRIC_INGRESS))
+			__throw_build_bug();
+
+		ctx_store_meta(ctx, 0, src);
+		ctx_store_meta(ctx, 1, dst);
+		ctx_store_meta(ctx, 2, reason);
+		ctx_store_meta(ctx, 3, dst_id);
+		ctx_store_meta(ctx, 4, exitcode | file << 8 | line << 16);
+
+		update_metrics(ctx_full_len(ctx), direction, (__u8)reason);
+		ep_tail_call(ctx, CILIUM_CALL_DROP_NOTIFY);
+
+		return exitcode;
+	}
+	```
+
+* **__send_drop_notify**
+	```c
+	__section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_DROP_NOTIFY)
+	int __send_drop_notify(struct __ctx_buff *ctx)
+	{
+		/* Mask needed to calm verifier. */
+		__u32 error = ctx_load_meta(ctx, 2) & 0xFFFFFFFF;
+		__u64 ctx_len = ctx_full_len(ctx);
+		__u64 cap_len = min_t(__u64, TRACE_PAYLOAD_LEN, ctx_len);
+		__u32 meta4 = ctx_load_meta(ctx, 4);
+		__u16 line = (__u16)(meta4 >> 16);
+		__u8 file = (__u8)(meta4 >> 8);
+		__u8 exitcode = (__u8)meta4;
+		struct drop_notify msg;
+
+		msg = (typeof(msg)) {
+			__notify_common_hdr(CILIUM_NOTIFY_DROP, (__u8)error),
+			__notify_pktcap_hdr(ctx_len, (__u16)cap_len),
+			.src_label	= ctx_load_meta(ctx, 0),
+			.dst_label	= ctx_load_meta(ctx, 1),
+			.dst_id		= ctx_load_meta(ctx, 3),
+			.line           = line,
+			.file           = file,
+			.ext_error      = (__s8)(__u8)(error >> 8),
+			.ifindex        = ctx_get_ifindex(ctx),
+		};
+
+		ctx_event_output(ctx, &EVENTS_MAP,
+				(cap_len << 32) | BPF_F_CURRENT_CPU,
+				&msg, sizeof(msg));
+
+		return exitcode;
+	}
+	```
+#### OFF
+* **_send_drop_notify**
+	```c
+	static __always_inline
+	int _send_drop_notify(__u8 file __maybe_unused, __u16 line __maybe_unused, sturct __ctx_buff *ctx, __u32 src __maybe_unused, __u32 dst __maybe_unused, __u32 dst_id __maybe_unused, __u32 reason, __u32 exitcode, enum metric_dir direction)
+	{
+		update_metrics(ctx_full_len(ctx), direction, (__u8)reason);
+		return exitcode;
+	}
+	```
+
+## 해결 과정
+```c
+if(!revalidate_data(ctx, &data, &data_end, &ip4))
+	return send_drop_notify(_, _, _, _, _, _, _);
+```
+위 코드에서 인자를 채워야 함.
+```c
+send_drop_notify(ctx, src, dst, dst_id, reason, exitcode, direction)
+```
+위 함수의 src, dst, dst_id, reason, exitcode, direction의 인자로 무엇이 들어가는지 확인 해야함.
+
+```c
+/**
+ * send_drop_notify
+ * @ctx:	socket buffer
+ * @src:	source identity
+ * @dst:	destination identity
+ * @dst_id:	designated destination endpoint ID, if ingress, otherwise 0
+ * @reason:	Reason for drop
+ * @exitcode:	error code to return to the kernel
+ *
+ * Generate a notification to indicate a packet was dropped.
+ *
+ * NOTE: This is terminal function and will cause the BPF program to exit
+ */
+```
+
+### 첫 번째 인자
+`send_drop_notify` 주석 설명에 따르면 첫번째 인자는 소켓 버퍼를 받는것을 알 수 있음.
+
+[bpf/include/bpf/ctx/skb.h](https://github.com/cilium/cilium/blob/master/bpf/include/bpf/ctx/skb.h)
+* __ctx_buff
+	```c
+	#define __ctx_buff		__sk_buff
+	```
+실질적으로 해당 위치에 macro를 이용해 `__sk_buff`를 `__ctx_buff`로 재정의 한 것을 확인 할 수 있음.\
+`send_drop_notify(ctx, _, _, _, _, _, _)`의 첫번째 인자로 `ctx`를 넣는것 확인.
+
+### 여섯번째 인자
+여섯번째 인자는 `exitcode`를 받는것을 알 수 있음.\
+[bpf/lib/common.h](https://github.com/cilium/cilium/blob/master/bpf/lib/common.h)
+* DROP_INVALID
+	```c
+	/* Cilium error codes, must NOT overlap with TC retrun code.
+	 * Thease also serve as drop reasons for metrics,
+	 * where reason > 0 corresponds to -(DROP_*)
+	 *
+	 * Thease are shared with pkg/montior/api/drop.go and api/v1/flow/flow.proto.
+	 * When modifying any of the below, those files should also be updated.
+	 */
+	#define DROP_UNUSED1		-130 /* unused */
+	#define DROP_UNUSED2		-131 /* unused */
+	...
+	#define DROP_INVALID		-134
+	```
+`send_drop_notify(ctx, _, _, _, _, DROP_INVALID, _)`의 6번째 인자로 `DROP_INVALID` 넣는것 확인.
+### 일곱 번째 인자
+`#define TAIL_CT_LOOKUP4(ID, NAME, DIR, CONDITION, TARGET_ID, TARGET_NAME)`의 3번째 인자가 `DIR`인것을 확인.\
+`TAIL_CT_LOOKUP4` 매크로를 이용해 생성되는 함수
+* `tail_ipv4_ct_ingress`
+	```c
+	TAIL_CT_LOOKUP4(CILIUM_CALL_IPV4_CT_INGRESS, tail_ipv4_ct_ingress, CT_INGRESS,
+		1, CILIUM_CALL_IPV4_TO_ENDPOINT, tail_ipv4_to_endpoint)
+	```
+* `tail_ipv4_ct_ingress_policy_only`
+	```c
+	TAIL_CT_LOOKUP4(CILIUM_CALL_IPV4_CT_INGRESS_POLICY_ONLY,
+		tail_ipv4_ct_ingress_policy_only, CT_INGRESS,
+		__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
+		CILIUM_CALL_IPV4_TO_LXC_POLICY_ONLY, tail_ipv4_policy)
+	```
+* `tail_ipv4_ct_egress` 
+	```c
+	TAIL_CT_LOOKUP4(CILIUM_CALL_IPV4_CT_EGRESS, tail_ipv4_ct_egress, CT_EGRESS,
+		is_defined(ENABLE_PER_PACKET_LB),
+		CILIUM_CALL_IPV4_FROM_LXC_CONT, tail_handle_ipv4_cont)
+
+	```
+위 3 함수는 `DIR`의 인자로 `CT_INGRESS`, `CT_EGRESS`가 들어오는 것을 확인.
+
+[bpf/lib/common.h](https://github.com/cilium/cilium/blob/master/bpf/lib/common.h)
+* ct_dir
+	```enum
+	enum ct_dir {
+		CT_EGRESS,
+		CT_INGRESS,
+		CT_SERVICE,
+	} __packed
+	```
+로 정의되어 있는것을 확인함.\
+```c
+	static __always_inline int
+	_send_drop_notify(__u8 file, __u16 line, struct __ctx_buff *ctx,
+			__u32 src, __u32 dst, __u32 dst_id,
+			__u32 reason, __u32 exitcode, enum metric_dir direction)
+```
+허나 `_send_drop_notify`의 경우 `enum metric_dir direction`을 받기에 `converting`이 필요함.
+
+[bpf/lib/metrics.h](https://github.com/cilium/cilium/blob/master/bpf/lib/metrics.h)
+* ct_to_metrics_dir
+	```c
+	static __always_inline enum metric_dir ct_to_metrics_dir(enum ct_dir ct_dir)
+	{
+		switch (ct_dir) {
+		case CT_INGRESS:
+			return METRIC_INGRESS;
+		case CT_EGRESS:
+			return METRIC_EGRESS;
+		case CT_SERVICE:
+			return METRIC_SERVICE;
+		default:
+			return 0;
+		}
+	}
+	```
+위의 `ct_to_metrics_dir`함수를 이용해 7번째 인자를 채우면 됨.\
+`send_drop_notify(ctx, _, _, _, _, DROP_INVALID, ct_to_metrics_dir(DIR))`

--- a/2023/ISSUE-22527/learning.md
+++ b/2023/ISSUE-22527/learning.md
@@ -1,0 +1,83 @@
+# Learning
+
+## Linux Connection Tracking
+### 참조자료
+* https://arthurchiao.art/blog/conntrack-design-and-implementation/#1-introduction
+
+### 개요
+`Conntrack`은 수 많은 네트워크 서비스 및 어플리케이션의 기반.\
+대표적은 것들로는 `Kubernetes Service`, `ServiceMesh Sidecar`, `LVS/IPVS`, `Docker Network`, `OpenSwitch(OVS)`, `OpenStack security group`등이 있음.
+
+## iproute2 BPF
+### 참조자료
+* https://docs.cilium.io/en/stable/bpf/toolchain/#iproute2
+* https://github.com/cilium/iproute2/blob/libbpf-static-data/include/bpf_elf.h
+
+### 개요
+BPF 프로그램을 커널에 적재하는 다양한 프론트앤드들이 존재하는것을 확인.\
+`bcc`, `perf`, `iproute2`가 대표적임.\
+`Cilium`의 `BPF Loader`는 `XDP`, `tc`, `lwt`유형의 네트워킹 프로그램을 로드하기 위해  `iproute2 BPF Loade`로 구현되었음.\
+향후 `Cilium`은 `native BPF Loader`를 탑재할 예정이지만, 개발 및 디버깅을 용이하게 하기 위해 `iporoute2` 제품군을 통해 로드할 수 있도록 호환될 것.
+
+### [struct bpf_elf_map](https://github.com/cilium/iproute2/blob/libbpf-static-data/include/bpf_elf.h)
+`iproute2`가 제공하는 `struct bpf_elf_map`에 대해 주목할 필요가 있음.\
+상당수의 코드에서 `__section_tail(ID, KEY)`macro를 사용하는것을 볼 수 있음.
+* **example**
+	```c
+	[...]
+
+	#ifndef __stringify
+	# define __stringify(X)   #X
+	#endif
+
+	#ifndef __section
+	# define __section(NAME)                  \
+	__attribute__((section(NAME), used))
+	#endif
+
+	#ifndef __section_tail
+	# define __section_tail(ID, KEY)          \
+	__section(__stringify(ID) "/" __stringify(KEY))
+	#endif
+
+	#ifndef BPF_FUNC
+	# define BPF_FUNC(NAME, ...)              \
+	(*NAME)(__VA_ARGS__) = (void *)BPF_FUNC_##NAME
+	#endif
+
+	#define BPF_JMP_MAP_ID   1
+
+	static void BPF_FUNC(tail_call, struct __sk_buff *skb, void *map,
+						uint32_t index);
+
+	struct bpf_elf_map jmp_map __section("maps") = {
+		.type           = BPF_MAP_TYPE_PROG_ARRAY,
+		.id             = BPF_JMP_MAP_ID,
+		.size_key       = sizeof(uint32_t),
+		.size_value     = sizeof(uint32_t),
+		.pinning        = PIN_GLOBAL_NS,
+		.max_elem       = 1,
+	};
+
+	__section_tail(BPF_JMP_MAP_ID, 0)
+	int looper(struct __sk_buff *skb)
+	{
+		printk("skb cb: %u\n", skb->cb[0]++);
+		tail_call(skb, &jmp_map, 0);
+		return TC_ACT_OK;
+	}
+
+	__section("prog")
+	int entry(struct __sk_buff *skb)
+	{
+		skb->cb[0] = 0;
+		tail_call(skb, &jmp_map, 0);
+		return TC_ACT_OK;
+	}
+
+	char __license[] __section("license") = "GPL";
+	```
+`iproute2`의 `BPF Loader`의 경우 위 예시코드를 로딩하면서 `__section_tail()`로 표시된 섹션도 인식함.\
+`__section_tail(ID, KEY)`에서 ID를 기반으로 `bpf_elf_map`이 제공하는 id와 비교하여 입력된 KEY를 통해 해당 인덱스에 적재됨.\
+결과적으로 제공된 모든 테일 호출 섹션은 `iproute2`의 `BPF Loader`에 의해 해당 맵으로 적재됨.\
+해당 메커니즘은 `tc`뿐만 아니라 `iproute2`가 지원하는 다른 BPF 프로그램 유형(`XDP`, `lwt`)에도 적용 가능.

--- a/2023/README.md
+++ b/2023/README.md
@@ -1,4 +1,4 @@
 # 2023
 
 ## Issue List
-###  [ISSUE-22527](./03/ISSUE-22527/ISSUE-22527.md) - bpf_lxc's CT programs are missing drop notifications
+### [ISSUE-22527](./ISSUE-22527/ISSUE-22527.md) - bpf_lxc's CT programs are missing drop notifications -> 다른 컨트리뷰터가 해결


### PR DESCRIPTION
## 학습한것
### Conntrack
> `Conntrack`은 수 많은 네트워크 서비스 및 어플리케이션의 기반.\
> 대표적은 것들로는 `Kubernetes Service`, `ServiceMesh Sidecar`, `LVS/IPVS`, `Docker Network`, `OpenSwitch(OVS)`, `OpenStack security group`등이 있음.
> 또한 커널 내부의 `ct_tuple`등에 대해 알게됨.

### BPF Frontend
>BPF 프로그램을 커널에 적재하는 다양한 프론트앤드들이 존재하는것을 확인.\
> `bcc`, `perf`, `iproute2`가 대표적임.\
> `Cilium`의 `BPF Loader`는 `XDP`, `tc`, `lwt`유형의 네트워킹 프로그램을 로드하기 위해  `iproute2 BPF Loade`로 구현되었음.\
향후 `Cilium`은 `native BPF Loader`를 탑재할 예정이지만, 개발 및 디버깅을 용이하게 하기 위해 `iporoute2` 제품군을 통해 로드할 수 있도록 호환될 것.